### PR TITLE
crash when using faye-redis

### DIFF
--- a/faye-redis.js
+++ b/faye-redis.js
@@ -150,7 +150,7 @@ Engine.prototype = {
         self._redis.publish(self._ns + '/notifications', clientId);
 
         self.clientExists(clientId, function(exists) {
-          if (!exists) this._redis.del(queue);
+          if (!exists) self._redis.del(queue);
         });
       });
     };


### PR DESCRIPTION
code uses this while it should be using self to access _redis.

error without the fix:

TypeError: Cannot call method 'del' of undefined
    at Engine.publish.notify (/Users/psq/src/node/fc/node_modules/faye-redis/faye-redis.js:153:36)
    at Engine.clientExists (/Users/psq/src/node/fc/node_modules/faye-redis/faye-redis.js:72:16)
    at try_callback (/Users/psq/src/node/fc/node_modules/faye-redis/node_modules/redis/index.js:532:9)
    at RedisClient.return_reply (/Users/psq/src/node/fc/node_modules/faye-redis/node_modules/redis/index.js:614:13)
    at ReplyParser.RedisClient.init_parser (/Users/psq/src/node/fc/node_modules/faye-redis/node_modules/redis/index.js:266:14)
    at ReplyParser.EventEmitter.emit (events.js:96:17)
    at ReplyParser.send_reply (/Users/psq/src/node/fc/node_modules/faye-redis/node_modules/redis/lib/parser/javascript.js:300:10)
    at ReplyParser.execute (/Users/psq/src/node/fc/node_modules/faye-redis/node_modules/redis/lib/parser/javascript.js:203:22)
    at RedisClient.on_data (/Users/psq/src/node/fc/node_modules/faye-redis/node_modules/redis/index.js:488:27)
    at Socket.<anonymous> (/Users/psq/src/node/fc/node_modules/faye-redis/node_modules/redis/index.js:82:14)
