### PR TITLE
self vs this fix for inside a callback

### DIFF
--- a/faye-redis.js
+++ b/faye-redis.js
@@ -150,7 +150,7 @@ Engine.prototype = {
         self._redis.publish(self._ns + '/notifications', clientId);
 
         self.clientExists(clientId, function(exists) {
-          if (!exists) this._redis.del(queue);
+          if (!exists) self._redis.del(queue);
         });
       });
     };


### PR DESCRIPTION
i was getting

TypeError: Cannot call method 'del' of undefined

and when I did

console.log(this._redis) inside the callback sure enough it was undefined.

self._redis seems to be correct?  Thanks for reviewing this pull request.
