### PR TITLE
actually use the reference to self that we stash in the closure

### DIFF
--- a/faye-redis.js
+++ b/faye-redis.js
@@ -150,7 +150,7 @@ Engine.prototype = {
         self._redis.publish(self._ns + '/notifications', clientId);
 
         self.clientExists(clientId, function(exists) {
-          if (!exists) this._redis.del(queue);
+          if (!exists) self._redis.del(queue);
         });
       });
     };


### PR DESCRIPTION
Without this patch, faye-redis will randomly crash on me.  This happens particularly when clients are rapidly connecting/disconnecting. I believe https://groups.google.com/forum/?fromgroups=#!topic/faye-users/0OJHVxpOU4E experienced exactly the same problem as me.
