### PR TITLE
Accept redis & subscriber client as options

### DIFF
--- a/faye-redis.js
+++ b/faye-redis.js
@@ -8,13 +8,18 @@ var Engine = function(server, options) {
       db     = this._options.database || this.DEFAULT_DATABASE,
       auth   = this._options.password,
       gc     = this._options.gc       || this.DEFAULT_GC,
-      socket = this._options.socket;
+      socket = this._options.socket,
+      redisClient = this._options.redisClient,
+      subscriberClient = this._options.subscriberClient;
 
   this._ns  = this._options.namespace || '';
 
   if (socket) {
     this._redis = redis.createClient(socket, {no_ready_check: true});
     this._subscriber = redis.createClient(socket, {no_ready_check: true});
+  } else if (redisClient && subscriberClient) {
+    this._redis = redisClient;
+    this._subscriber = subscriberClient;
   } else {
     this._redis = redis.createClient(port, host, {no_ready_check: true});
     this._subscriber = redis.createClient(port, host, {no_ready_check: true});


### PR DESCRIPTION
Wondering if we could accept options for the `redis` & `subscriber` objects.

It'd be nice if we can pass in a custom redis client (any `node_redis` compatible client). I'm trying to use [node-redis-sentinel](https://github.com/ortoo/node-redis-sentinel) which is a `node_redis` compatible client that implements the [redis sentinel connection routine](http://redis.io/topics/sentinel) for a high availability redis setup.

The submitted code is just to get the discussion started, it could probably use some tweaks.
