### PR TITLE
Pin Redis version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 , "version"         : "0.2.0"
 , "engines"         : {"node": ">=0.4.0"}
 , "main"            : "./faye-redis"
-, "dependencies"    : {"redis": ""}
+, "dependencies"    : {"redis": "2.6.0-2"}
 , "devDependencies" : {"jstest": ""}
 
 , "scripts"         : {"test": "node spec/runner.js"}


### PR DESCRIPTION
The loose version of Redis in package.json caused an upgrade to a broken/incompatible version of Redis. Redis 2.6.0-2 seems to be the last known working version.

It would be a solution to #23.
