### PR TITLE
Fix race condition with publishing to clients from subscribe monitor

### DIFF
--- a/faye-redis.js
+++ b/faye-redis.js
@@ -122,22 +122,22 @@ Engine.prototype = {
   subscribe: function(clientId, channel, callback, context) {
     var self = this;
     this._redis.sadd(this._ns + '/clients/' + clientId + '/channels', channel, function(error, added) {
-      if (added === 1) self._server.trigger('subscribe', clientId, channel);
-    });
-    this._redis.sadd(this._ns + '/channels' + channel, clientId, function() {
-      self._server.debug('Subscribed client ? to channel ?', clientId, channel);
-      if (callback) callback.call(context);
+      self._redis.sadd(self._ns + '/channels' + channel, clientId, function() {
+        self._server.debug('Subscribed client ? to channel ?', clientId, channel);
+        if (added === 1) self._server.trigger('subscribe', clientId, channel);
+        if (callback) callback.call(context);
+      });
     });
   },
 
   unsubscribe: function(clientId, channel, callback, context) {
     var self = this;
     this._redis.srem(this._ns + '/clients/' + clientId + '/channels', channel, function(error, removed) {
-      if (removed === 1) self._server.trigger('unsubscribe', clientId, channel);
-    });
-    this._redis.srem(this._ns + '/channels' + channel, clientId, function() {
-      self._server.debug('Unsubscribed client ? from channel ?', clientId, channel);
-      if (callback) callback.call(context);
+      self._redis.srem(self._ns + '/channels' + channel, clientId, function() {
+        self._server.debug('Unsubscribed client ? from channel ?', clientId, channel);
+        if (removed === 1) self._server.trigger('unsubscribe', clientId, channel);
+        if (callback) callback.call(context);
+      });
     });
   },
 


### PR DESCRIPTION
## Problem
If you have a `subscribe` monitor that publishes to a client in its callback, the publish call can race with the completion of a subscription for that client. In the failure case a client may miss one or more messages completely.

Given the current subscribe method:
```javascript
  subscribe: function(clientId, channel, callback, context) {
    var self = this;
->  this._redis.sadd(this._ns + '/clients/' + clientId + '/channels', channel, function(error, added) {
      if (added === 1) self._server.trigger('subscribe', clientId, channel);
    });
->  this._redis.sadd(this._ns + '/channels' + channel, clientId, function() {
      self._server.debug('Subscribed client ? to channel ?', clientId, channel);
      if (callback) callback.call(context);
    });
  },
```

The two `sadd` calls race with each other for completion. When the first `sadd` completes before the second, the `subscribe` callback may be executed before the clientId has been stored in the channel list. When this happens, calls to publish on the same channel will not publish to the newly subscribed client.

You can artificially add latency using setTimeout to make the race easier to see:
```javascript
  subscribe: function(clientId, channel, callback, context) {
    var self = this;
    this._redis.sadd(this._ns + '/clients/' + clientId + '/channels', channel, function(error, added) {
      if (added === 1) self._server.trigger('subscribe', clientId, channel);
    });
    setTimeout(function(){
      self._redis.sadd(self._ns + '/channels' + channel, clientId, function () {
        self._server.debug('Subscribed client ? to channel ?', clientId, channel);
        if (callback) callback.call(context);
      });
    },20);
  },
```

In our testing, 20ms of latency reproduced approximately a 50/50 failure case, while 500ms produced a 100% failure rate.

## Solution
Wait for all subscription state to have been updated in redis before invoking the `subscribe` or `unsubscribe` monitors.