### PR TITLE
Constrain the version of redis for compatibility.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 , "version"         : "0.2.0"
 , "engines"         : {"node": ">=0.4.0"}
 , "main"            : "./faye-redis"
-, "dependencies"    : {"redis": ""}
+, "dependencies"    : {"redis": "<4.0.0"}
 , "devDependencies" : {"jstest": ""}
 
 , "scripts"         : {"test": "node spec/runner.js"}


### PR DESCRIPTION
The redis package introduces incompatible breaking changes in the 4.x version. A migration guide can be found at https://github.com/redis/node-redis/blob/master/docs/v3-to-v4.md#all-of-the-breaking-changes